### PR TITLE
Fix arch detection for-loop to use category strings from detect_gpu.py

### DIFF
--- a/install.bat
+++ b/install.bat
@@ -300,7 +300,7 @@ echo [*] Installing bitsandbytes if available...
 set "install_bnb_new=0"
 
 REM ---- check newer supported architectures ----
-for %%G in (gfx90a gfx942 gfx950 gfx1100 gfx1101 gfx1150 gfx1151 gfx1200 gfx1201) do (
+for %%G in (gfx90X gfx94X gfx950 gfx110X gfx1150 gfx1151 gfx1152 gfx1153 gfx120X) do (
     if /I "!arch!"=="%%G" set "install_bnb_new=1"
 )
 
@@ -334,7 +334,7 @@ if errorlevel 1 goto :install_failed
 echo [*] Installing flash-attention if available...
 
 set "install_fa=0"
-for %%G in (gfx90a gfx942 gfx950 gfx1100 gfx1101 gfx1102 gfx1150 gfx1151 gfx1152 gfx1153 gfx1200 gfx1201) do (
+for %%G in (gfx90X gfx94X gfx950 gfx110X gfx1150 gfx1151 gfx1152 gfx1153 gfx120X) do (
     if /I "!arch!"=="%%G" set "install_fa=1"
 )
 if /I "!install_fa!"=="1" goto :install_fa


### PR DESCRIPTION
`detect_gpu.py` returns category strings such as `gfx110X`, `gfx120X`, `gfx90X`, etc., but the architecture checks for bitsandbytes and flash-attention were comparing against specific GPU identifiers like `gfx1100`, `gfx1200`, `gfx90a`, which never matched.
As a result, bitsandbytes and flash-attention were silently skipped for all RDNA3, RDNA4, and datacenter GPU users.

This PR fixes the architecture checks to use the category strings returned by `detect_gpu.py`.