### PR TITLE
Set HIP_PATH via rocm-sdk for flash-attn triton backend

### DIFF
--- a/comfyui-rocm.bat
+++ b/comfyui-rocm.bat
@@ -8,6 +8,8 @@ set "PATH=%PYTHON_DIR%;%PYTHON_DIR%\Scripts;%PATH%"
 
 .\python_env\scripts\rocm-sdk init >nul 2>&1
 
+for /f "delims=" %%i in ('rocm-sdk path --root') do set "HIP_PATH=%%i"
+
 REM Launch ComfyUI with your parameters
 python_env\python.exe main.py ^
 --use-quad-cross-attention ^


### PR DESCRIPTION
Without `HIP_PATH` set, `triton-windows` fails to compile `hip_utils` on first run, causing flash-attention to error out on import.

This PR adds a single line to `comfyui-rocm.bat` that derives `HIP_PATH` from `rocm-sdk path --root`.