### PR TITLE
fix: replace deprecated wmic with Get-CimInstance for GPU detection

### DIFF
--- a/detect_gpu.py
+++ b/detect_gpu.py
@@ -44,7 +44,8 @@ def detect_gpu():
     try:
         # Query AMD GPUs via WMI
         result = subprocess.run(
-            ['wmic', 'path', 'win32_videocontroller', 'get', 'name'],
+            ['powershell', '-NoProfile', '-Command',
+             'Get-CimInstance Win32_VideoController | Select-Object -ExpandProperty Name'],
             capture_output=True,
             text=True,
             check=False


### PR DESCRIPTION
This PR replaces `wmic` with PowerShell's `Get-CimInstance` for GPU detection. Verified on Windows 11.
In theory, it fixes https://github.com/patientx-cfz/comfyui-rocm/issues/3.