### PR TITLE
Fix gfx94X echo typo, remove duplicate GPU entry, remove stale errorlevel check

### DIFF
--- a/detect_gpu.py
+++ b/detect_gpu.py
@@ -36,7 +36,7 @@ GPU_TO_GFX = [
     (['rx 5500', 'radeon pro v520'], 'gfx101X', 'RDNA 1', True),
     
     # Data Center / Enterprise GPUs
-    (['radeon pro vii', 'radeon pro vii'], 'gfx90X', 'Radeon Pro VII', True),
+    (['radeon pro vii'], 'gfx90X', 'Radeon Pro VII', True),
     (['mi300a', 'mi300x', 'mi325x'], 'gfx94X', 'MI300/MI325', True),
     (['mi350x', 'mi355x'], 'gfx950', 'MI350/MI355', True),
 ]

--- a/install.bat
+++ b/install.bat
@@ -232,7 +232,7 @@ if "!arch!"=="gfx94X" (
     if errorlevel 1 (
         echo [!] Warning: rocm-sdk init failed, continuing anyway...
     )
-	echo [*] Installing PyTorch for Radeon Pro VII ^(gfx90X^)...
+	echo [*] Installing PyTorch for MI300/MI325 ^(gfx94X^)...
     .\python_env\python.exe -m pip install --index-url https://rocm.nightlies.amd.com/v2-staging/gfx94X-dcgpu/ torch torchaudio torchvision --no-warn-script-location >nul 2>&1
     if errorlevel 1 goto :install_failed
     goto :install_requirements
@@ -325,8 +325,6 @@ goto :bnb_done
 echo No compatible bitsandbytes build for !arch!
 
 :bnb_done
-
-if errorlevel 1 goto :install_failed
 
 echo [*] Installing flash-attention if available...
 


### PR DESCRIPTION
Minor refactor: fix incorrect echo label in the `gfx94X` block, remove duplicate `Radeon Pro VII` entry in the GPU map, and remove a stale `errorlevel` check after `:bnb_done`.