### PR TITLE
Fix custom_op schema error; install flash-attention on all archs

### DIFF
--- a/comfy/ldm/modules/attention.py
+++ b/comfy/ldm/modules/attention.py
@@ -662,23 +662,33 @@ def attention3_sage(q, k, v, heads, mask=None, attn_precision=None, skip_reshape
 
     return out
 
-try:
-    @torch.library.custom_op("flash_attention::flash_attn", mutates_args=())
+_is_rdna1_or_rdna2 = (
+    torch.version.hip is not None and
+    torch.cuda.is_available() and
+    torch.cuda.get_device_properties(0).gcnArchName.startswith(("gfx101", "gfx102", "gfx103"))
+)
+
+if not _is_rdna1_or_rdna2:
+    try:
+        @torch.library.custom_op("flash_attention::flash_attn", mutates_args=())
+        def flash_attn_wrapper(q: torch.Tensor, k: torch.Tensor, v: torch.Tensor,
+                        dropout_p: float = 0.0, causal: bool = False) -> torch.Tensor:
+            return flash_attn_func(q, k, v, dropout_p=dropout_p, causal=causal)
+
+        @flash_attn_wrapper.register_fake
+        def flash_attn_fake(q, k, v, dropout_p=0.0, causal=False):
+            # Output shape is the same as q
+            return q.new_empty(q.shape)
+    except AttributeError as error:
+        FLASH_ATTN_ERROR = error
+
+        def flash_attn_wrapper(q: torch.Tensor, k: torch.Tensor, v: torch.Tensor,
+                        dropout_p: float = 0.0, causal: bool = False) -> torch.Tensor:
+            assert False, f"Could not define flash_attn_wrapper: {FLASH_ATTN_ERROR}"
+else:
     def flash_attn_wrapper(q: torch.Tensor, k: torch.Tensor, v: torch.Tensor,
                     dropout_p: float = 0.0, causal: bool = False) -> torch.Tensor:
         return flash_attn_func(q, k, v, dropout_p=dropout_p, causal=causal)
-
-
-    @flash_attn_wrapper.register_fake
-    def flash_attn_fake(q, k, v, dropout_p=0.0, causal=False):
-        # Output shape is the same as q
-        return q.new_empty(q.shape)
-except AttributeError as error:
-    FLASH_ATTN_ERROR = error
-
-    def flash_attn_wrapper(q: torch.Tensor, k: torch.Tensor, v: torch.Tensor,
-                    dropout_p: float = 0.0, causal: bool = False) -> torch.Tensor:
-        assert False, f"Could not define flash_attn_wrapper: {FLASH_ATTN_ERROR}"
 
 @wrap_attn
 def attention_flash(q, k, v, heads, mask=None, attn_precision=None, skip_reshape=False, skip_output_reshape=False, **kwargs):

--- a/install.bat
+++ b/install.bat
@@ -337,10 +337,10 @@ curl -sL -o python_env\Lib\site-packages\sageattention\quant_per_block.py https:
 
 echo [*] Installing bitsandbytes if available...
 
-:: Skip unsupported architectures (MI300/MI350 series)
+:: Skip unsupported architectures (MI300/MI350 series) as they are not supported by prebuilt wheels
 for %%G in (gfx90X gfx94X gfx950) do (
     if /I "!arch!"=="%%G" (
-        echo [*] Skipping bitsandbytes for !arch! - not supported
+        echo [*] Skipping bitsandbytes for !arch! - prebuilt wheels are not available, build from source required
         goto :bnb_done
     )
 )
@@ -352,25 +352,14 @@ if errorlevel 1 goto :install_failed
 
 :bnb_done
 
-echo [*] Installing flash-attention if available...
-
-set "install_fa=0"
-for %%G in (gfx90X gfx94X gfx950 gfx110X gfx1150 gfx1151 gfx1152 gfx1153 gfx120X) do (
-    if /I "!arch!"=="%%G" set "install_fa=1"
-)
-if /I "!install_fa!"=="1" goto :install_fa
-echo [*] Skipping flash-attention on !arch!...
-goto :fa_done
-
-:install_fa
-echo [*] Installing flash-attention for !arch!...
+echo [*] Installing flash-attention (aiter triton backend)...
 .\python_env\python.exe -m pip install https://github.com/0xDELUXA/flash-attention/releases/download/v2.8.4_win-rocm/flash_attn-2.8.4-py3-none-win_amd64.whl --quiet
 if errorlevel 1 (
     echo [!] Warning: flash-attention install failed, skipping...
     goto :fa_done
 )
 .\python_env\python.exe -m pip install https://github.com/0xDELUXA/flash-attention/releases/download/v2.8.4_win-rocm/amd_aiter-0.0.0-py3-none-win_amd64.whl --quiet
-if errorlevel 1 echo [!] Warning: aiter install failed, flash-attention may not work...
+if errorlevel 1 echo [!] Warning: aiter install failed, flash-attention will not work...
 
 :fa_done
 


### PR DESCRIPTION
Fixes a flash-attention issue on older architectures:
- `attention.py`: 
  - On RDNA1/RDNA2 (`gfx101x`, `gfx102x`, `gfx103x`), skip `torch.library.custom_op` registration entirely and use a plain `flash_attn_func` wrapper instead. This silently works around the `schema_.has_value() INTERNAL ASSERT FAILED` error caused by broken custom op schema dispatch on these architectures. All other GPUs continue to use the original `custom_op` registration path unchanged.

- `install.bat`: 
  - Removed the architecture allowlist for flash-attention, it now installs on all architectures.
  - Mark flash-attention as non-functional if aiter install fails
  - Updated bitsandbytes skip message to clarify that prebuilt wheels are not available; users can build from source.