### PR TITLE
Re-enabled pytorch attention in VAE

### DIFF
--- a/comfy/ldm/modules/diffusionmodules/model.py
+++ b/comfy/ldm/modules/diffusionmodules/model.py
@@ -328,7 +328,7 @@ def vae_attention():
     if model_management.xformers_enabled_vae():
         logging.info("Using xformers attention in VAE")
         return xformers_attention
-    elif model_management.pytorch_attention_enabled_vae():
+    elif model_management.pytorch_attention_enabled():
         logging.info("Using pytorch attention in VAE")
         return pytorch_attention
     else:

--- a/comfy/model_management.py
+++ b/comfy/model_management.py
@@ -1445,11 +1445,6 @@ def pytorch_attention_enabled():
     global ENABLE_PYTORCH_ATTENTION
     return ENABLE_PYTORCH_ATTENTION
 
-def pytorch_attention_enabled_vae():
-    if is_amd():
-        return False  # enabling pytorch attention on AMD currently causes crash when doing high res
-    return pytorch_attention_enabled()
-
 def pytorch_attention_flash_attention():
     global ENABLE_PYTORCH_ATTENTION
     if ENABLE_PYTORCH_ATTENTION:


### PR DESCRIPTION
Just noticed that the pytorch attention in VAE disablement for the ancient ROCm version was forgotten: https://github.com/Comfy-Org/ComfyUI/commit/1cd6cd608086a8ff8789b747b8d4f8b9273e576e

Related:
- https://github.com/Comfy-Org/ComfyUI/pull/8289

- https://github.com/Comfy-Org/ComfyUI/pull/9956