### PR TITLE
better install: streamline GPU detection and pip configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ extra_model_paths.yaml
 .idea/
 venv*/
 .venv/
+python_env/
 /web/extensions/*
 !/web/extensions/logging.js.example
 !/web/extensions/core/

--- a/detect_gpu.py
+++ b/detect_gpu.py
@@ -3,43 +3,43 @@ import sys
 import os
 
 # Comprehensive mapping of GPU model numbers to gfx codes
-# Format: (model_list, gfx_code, architecture_name, supported)
+# Format: (model_list, gfx_code, arch_index_suffix, architecture_name, supported)
 GPU_TO_GFX = [
     # RDNA4 (gfx12xx)
-    (['rx 9060'], 'gfx120X', 'RDNA 4', True),
-    (['rx 9070', 'r9070'], 'gfx120X', 'RDNA 4', True),
-    
+    (['rx 9060'], 'gfx120X', 'gfx120X-all/', 'RDNA 4', True),
+    (['rx 9070', 'r9070'], 'gfx120X', 'gfx120X-all/', 'RDNA 4', True),
+
     # RDNA3.5 (gfx115x)
-    (['890m'], 'gfx1150', 'Strix Point', True),
-    (['8060s', '8050s', '8040s', '880m'], 'gfx1151', 'Strix Halo', True),
-    (['860m', '840m', '820m'], 'gfx1152', 'Krackan Point', True),
-    (['gfx1153'], 'gfx1153', 'RDNA 3.5', True),
-    
+    (['890m'], 'gfx1150', 'gfx1150/', 'Strix Point', True),
+    (['8060s', '8050s', '8040s', '880m'], 'gfx1151', 'gfx1151/', 'Strix Halo', True),
+    (['860m', '840m', '820m'], 'gfx1152', 'gfx1152/', 'Krackan Point', True),
+    (['gfx1153'], 'gfx1153', 'gfx1153/', 'RDNA 3.5', True),
+
     # RDNA3 (gfx110x)
-    (['rx 7900', 'w7900', 'w7800'], 'gfx110X', 'RDNA 3', True),
-    (['rx 7800', 'rx 7700', 'w7700'], 'gfx110X', 'RDNA 3', True),
-    (['rx 7700s', 'rx 7650', 'rx 7600', 'w7600', 'w7500', 'rx 7400', 'w7400'], 'gfx110X', 'RDNA 3', True),
-    (['780m', '760m', '740m'], 'gfx110X', 'RDNA 3', True),
-       
+    (['rx 7900', 'w7900', 'w7800'], 'gfx110X', 'gfx110X-all/', 'RDNA 3', True),
+    (['rx 7800', 'rx 7700', 'w7700'], 'gfx110X', 'gfx110X-all/', 'RDNA 3', True),
+    (['rx 7700s', 'rx 7650', 'rx 7600', 'w7600', 'w7500', 'rx 7400', 'w7400'], 'gfx110X', 'gfx110X-all/', 'RDNA 3', True),
+    (['780m', '760m', '740m'], 'gfx110X', 'gfx110X-all/', 'RDNA 3', True),
+
     # RDNA2 (gfx103x) - SUPPORTED
-    (['rx 6950', 'rx 6900', 'rx 6800', 'w6800', 'v620'], 'gfx103X', 'RDNA 2', True),  # gfx1030
-    (['rx 6750', 'rx 6700', 'rx 6800m', 'rx 6700m', 'rx 6800s', 'rx 6700s'], 'gfx103X', 'RDNA 2', True),  # gfx1031
-    (['rx 6650', 'rx 6600', 'w6600', 'rx 6650m', 'rx 6600m', 'rx 6600s'], 'gfx103X', 'RDNA 2', True),  # gfx1032
-    (['rx 6500', 'w6500', 'rx 6500m'], 'gfx103X', 'RDNA 2', True),  # gfx1034
+    (['rx 6950', 'rx 6900', 'rx 6800', 'w6800', 'v620'], 'gfx103X', 'gfx103X-dgpu/', 'RDNA 2', True),  # gfx1030
+    (['rx 6750', 'rx 6700', 'rx 6800m', 'rx 6700m', 'rx 6800s', 'rx 6700s'], 'gfx103X', 'gfx103X-dgpu/', 'RDNA 2', True),  # gfx1031
+    (['rx 6650', 'rx 6600', 'w6600', 'rx 6650m', 'rx 6600m', 'rx 6600s'], 'gfx103X', 'gfx103X-dgpu/', 'RDNA 2', True),  # gfx1032
+    (['rx 6500', 'w6500', 'rx 6500m'], 'gfx103X', 'gfx103X-dgpu/', 'RDNA 2', True),  # gfx1034
 
     # RDNA2 (gfx103x) - NOT SUPPORTED
-    (['680m', '660m'], 'gfx103X', 'RDNA 2', False),  # gfx1035 - iGPU
-    (['610m'], 'gfx103X', 'RDNA 2', False),  # gfx1036 - iGPU
-    (['rx 6550', 'rx 6450', 'rx 6400', 'w6400', 'rx 6300', 'w6300'], 'gfx103X', 'RDNA 2', False),
+    (['680m', '660m'], 'gfx103X', 'gfx103X-dgpu/', 'RDNA 2', False),  # gfx1035 - iGPU
+    (['610m'], 'gfx103X', 'gfx103X-dgpu/', 'RDNA 2', False),  # gfx1036 - iGPU
+    (['rx 6550', 'rx 6450', 'rx 6400', 'w6400', 'rx 6300', 'w6300'], 'gfx103X', 'gfx103X-dgpu/', 'RDNA 2', False),
 
     # RDNA1 (gfx101x)
-    (['rx 5700', 'rx 5600'], 'gfx101X', 'RDNA 1', True),
-    (['rx 5500', 'radeon pro v520'], 'gfx101X', 'RDNA 1', True),
-    
+    (['rx 5700', 'rx 5600'], 'gfx101X', 'gfx101X-dgpu/', 'RDNA 1', True),
+    (['rx 5500', 'radeon pro v520'], 'gfx101X', 'gfx101X-dgpu/', 'RDNA 1', True),
+
     # Data Center / Enterprise GPUs
-    (['radeon pro vii'], 'gfx90X', 'Radeon Pro VII', True),
-    (['mi300a', 'mi300x', 'mi325x'], 'gfx94X', 'MI300/MI325', True),
-    (['mi350x', 'mi355x'], 'gfx950', 'MI350/MI355', True),
+    (['radeon pro vii'], 'gfx90X', 'gfx90X-dcgpu/', 'Radeon Pro VII', True),
+    (['mi300a', 'mi300x', 'mi325x'], 'gfx94X', 'gfx94X-dcgpu/', 'MI300/MI325', True),
+    (['mi350x', 'mi355x'], 'gfx950', 'gfx950-dcgpu/', 'MI350/MI355', True),
 ]
 
 def detect_gpu_wmic():
@@ -51,7 +51,7 @@ def detect_gpu_wmic():
             check=False,
             timeout=10
         )
-        
+
         if result.returncode == 0:
             gpu_list = result.stdout.strip().split('\n')
             amd_gpus = []
@@ -74,7 +74,7 @@ def detect_gpu_powershell():
             check=False,
             timeout=10
         )
-        
+
         if result.returncode == 0:
             gpu_list = result.stdout.strip().split('\n')
             amd_gpus = []
@@ -89,65 +89,66 @@ def detect_gpu_powershell():
 
 def match_gpu_to_gfx(gpu_name):
     gpu_lower = gpu_name.lower()
-    
-    for model_list, gfx, arch_name, supported in GPU_TO_GFX:
+
+    for model_list, gfx, arch_index, arch_name, supported in GPU_TO_GFX:
         for model in model_list:
             if model in gpu_lower:
-                return gfx, arch_name, supported
-    
-    return None, None, False
+                return gfx, arch_index, arch_name, supported
+
+    return None, None, None, False
 
 def detect_gpu():
     print("Attempting to detect AMD GPU...")
-    
+
     # Try different detection methods in order of preference
     amd_gpus = []
-    
+
     # Method 1: wmic (fast and works on most systems)
     print("Trying wmic method...")
     amd_gpus = detect_gpu_wmic()
-    
+
     # Method 2: PowerShell (works on all modern Windows)
     if not amd_gpus:
         print("Trying PowerShell method...")
         amd_gpus = detect_gpu_powershell()
-    
+
     if not amd_gpus:
         print("No AMD GPU detected")
         print("If you have an AMD GPU, please ensure your drivers are installed.")
-        return None
-    
+        return None, None, None
+
     # Process detected GPUs
     print(f"\nFound {len(amd_gpus)} AMD GPU(s):")
     for gpu in amd_gpus:
         print(f"  - {gpu}")
-    
+
     # Try to match to known architectures
     for gpu in amd_gpus:
-        gfx, arch_name, supported = match_gpu_to_gfx(gpu)
-        
+        gfx, arch_index, arch_name, supported = match_gpu_to_gfx(gpu)
+
         if gfx and supported:
             print(f"\nMatched GPU: {gpu}")
             print(f"Architecture: {arch_name} ({gfx})")
             print("Status: SUPPORTED")
-            return gfx
+            return gfx, arch_index, arch_name
         elif gfx and not supported:
             print(f"\nMatched GPU: {gpu}")
             print(f"Architecture: {arch_name} ({gfx})")
             print("Status: NOT YET SUPPORTED - Coming in future updates")
-            return None
-    
+            return None, None, None
+
     # If we found AMD GPUs but couldn't match them
     print("\nGPU(s) found but architecture could not be identified.")
     print("Only RDNA1, RDNA2, RDNA3, and RDNA4 architectures are supported.")
     print("Please check if your GPU is compatible with ROCm.")
-    return None
+    return None, None, None
 
 if __name__ == "__main__":
     try:
-        gfx = detect_gpu()
+        gfx, arch_index, arch_name = detect_gpu()
         if gfx:
-            print(f"\n{gfx}")
+            # Output format: gfx|arch_index|arch_name (parsed by batch for /f)
+            print(f"{gfx}|{arch_index}|{arch_name}")
             sys.exit(0)
         else:
             sys.exit(1)

--- a/install.bat
+++ b/install.bat
@@ -145,21 +145,21 @@ if "!arch!"=="" (
 echo [*] Detected GPU architecture: !ARCH_NAME! ^(!arch!^)
 
 :: gfx120X requires --pre
-if "!arch!"=="gfx120X" set "PIP_PRE=true"
+if "!arch!"=="gfx120X" set "FLAG=--pre"
 
 :: Build full URL
-set "PIP_INDEX_URL=https://rocm.nightlies.amd.com/v2/!ARCH_INDEX!"
+set "FULL_INDEX_URL=https://rocm.nightlies.amd.com/v2/!ARCH_INDEX!"
 
 :: Install with index override
-echo [*] Installing ROCm and PyTorch for !ARCH_NAME! ^(!arch!^)...
-.\python_env\python.exe -m pip install torch torchaudio torchvision
+echo [*] Installing ROCm and PyTorch from !FULL_INDEX_URL! ...
+.\python_env\python.exe -m pip install -i !FULL_INDEX_URL! torch torchaudio torchvision !FLAG!
 if errorlevel 1 goto :install_failed
 
 :: Wait for installation
 timeout /t 1 /nobreak >nul 2>&1
 
-echo [*] Checking ROCm installation...
-.\python_env\python.exe -m pip install rocm[libraries,devel]
+echo [*] Checking ROCm SDK full installation...
+.\python_env\python.exe -m pip install -i !FULL_INDEX_URL! rocm[libraries,devel]
 if errorlevel 1 goto :install_failed
 
 echo [*] Initializing rocm-sdk...

--- a/install.bat
+++ b/install.bat
@@ -1,6 +1,10 @@
 @echo off
 cls
 setlocal enabledelayedexpansion
+set "PIP_REQUIRE_VIRTUALENV=false"
+set "PIP_NO_WARN_SCRIPT_LOCATION=true"
+set "PIP_QUIET=true"
+
 title comfyui-rocm Installer
 echo ====================================================
 echo        comfyui-rocm - Automatic Installer
@@ -19,7 +23,7 @@ echo [*] [1/7] Downloading Python 3.12 Embeddable...
 if not exist "python_env" mkdir "python_env"
 curl -L "https://www.python.org/ftp/python/3.12.9/python-3.12.9-embed-amd64.zip" -o "python_embed.zip" >nul 2>&1
 if errorlevel 1 (
-    echo [!] Error: Failed to download Python embeddable
+    echo [^^!] Error: Failed to download Python embeddable
     pause
     exit /b 1
 )
@@ -28,7 +32,7 @@ if errorlevel 1 (
 echo [*] [2/7] Downloading Python development files...
 curl -L https://www.python.org/ftp/python/3.12.9/python-3.12.9-amd64.zip -o python_full.zip >nul 2>&1
 if errorlevel 1 (
-    echo [!] Error: Failed to download Python installer
+    echo [^^!] Error: Failed to download Python installer
     del "python_embed.zip" >nul 2>&1
     pause
     exit /b 1
@@ -38,7 +42,7 @@ if errorlevel 1 (
 echo [*] [3/7] Extracting Python runtime...
 tar -xf "python_embed.zip" -C "python_env" >nul 2>&1
 if errorlevel 1 (
-    echo [!] Error: Failed to extract Python
+    echo [^^!] Error: Failed to extract Python
     pause
     exit /b 1
 )
@@ -57,14 +61,14 @@ if exist "pythonfull\include" (
     xcopy "pythonfull\include" "python_env\include\" /E /I /Q >nul 2>&1
     echo [*] - Headers copied
 ) else (
-    echo [!] Warning: Headers not found
+    echo [^^!] Warning: Headers not found
 )
 
 if exist "pythonfull\libs" (
     xcopy "pythonfull\libs" "python_env\libs\" /E /I /Q >nul 2>&1
     echo [*] - Libraries copied
 ) else (
-    echo [!] Warning: Libs not found
+    echo [^^!] Warning: Libs not found
 )
 
 :: Also copy the full Lib folder for completeness
@@ -90,22 +94,22 @@ echo import site
 echo [*] [7/7] Installing Pip and build tools...
 curl -L "https://bootstrap.pypa.io/get-pip.py" -o "get-pip.py" >nul 2>&1
 if errorlevel 1 (
-    echo [!] Error: Failed to download get-pip.py
+    echo [^^!] Error: Failed to download get-pip.py
     pause
     exit /b 1
 )
-.\python_env\python.exe get-pip.py --no-warn-script-location >nul 2>&1
+.\python_env\python.exe get-pip.py --no-warn-script-location
 if errorlevel 1 (
-    echo [!] Error: Failed to install pip
+    echo [^^!] Error: Failed to install pip
     pause
     exit /b 1
 )
 del "get-pip.py"
 
 :: Install build tools
-.\python_env\python.exe -m pip install --upgrade pip setuptools wheel --no-warn-script-location >nul 2>&1
+.\python_env\python.exe -m pip install --upgrade pip setuptools wheel --no-warn-script-location
 if errorlevel 1 (
-    echo [!] Error: Failed to install build tools
+    echo [^^!] Error: Failed to install build tools
     pause
     exit /b 1
 )
@@ -121,196 +125,60 @@ echo [*] Detecting GPU...
 
 :: Check if detect_gpu.py exists
 if not exist "detect_gpu.py" (
-    echo [!] Error: detect_gpu.py not found!
+    echo [^^!] Error: detect_gpu.py not found!
     pause
     exit /b 1
 )
 
-for /f "delims=" %%A in ('.\python_env\python.exe detect_gpu.py 2^>nul') do (
-    if not "%%A"=="" (
-        set "arch=%%A"
-    )
+for /f "tokens=1,2,3 delims=|" %%A in ('.\python_env\python.exe detect_gpu.py 2^>nul') do (
+    set "arch=%%A"
+    set "ARCH_INDEX=%%B"
+    set "ARCH_NAME=%%C"
 )
 
 if "!arch!"=="" (
-    echo [!] GPU detection failed or unsupported GPU
+    echo [^^!] GPU detection failed or unsupported GPU
     pause
     exit /b 1
 )
 
-echo [*] Detected GPU architecture: !arch!
+echo [*] Detected GPU architecture: !ARCH_NAME! ^(!arch!^)
 
-:: Install PyTorch based on detected GPU
-if "!arch!"=="gfx101X" (
-    echo [*] Installing ROCm for RDNA1 ^(gfx101X^)...
-    .\python_env\python.exe -m pip install rocm[devel,libraries] --index-url https://rocm.nightlies.amd.com/v2-staging/gfx101X-dgpu/ --no-warn-script-location >nul 2>&1
-    if errorlevel 1 goto :install_failed
-    .\python_env\scripts\rocm-sdk init >nul 2>&1 
-    if errorlevel 1 (
-        echo [!] Warning: rocm-sdk init failed, continuing anyway...
-    )
-	echo [*] Installing PyTorch for RDNA1 ^(gfx101X^)...
-    .\python_env\python.exe -m pip install --index-url https://rocm.nightlies.amd.com/v2-staging/gfx101X-dgpu/ torch torchaudio torchvision --no-warn-script-location >nul 2>&1
-    if errorlevel 1 goto :install_failed
-    goto :install_requirements
+:: gfx120X requires --pre
+if "!arch!"=="gfx120X" set "PIP_PRE=true"
+
+:: Build full URL
+set "PIP_INDEX_URL=https://rocm.nightlies.amd.com/v2/!ARCH_INDEX!"
+
+:: Install with index override
+echo [*] Installing ROCm and PyTorch for !ARCH_NAME! ^(!arch!^)...
+.\python_env\python.exe -m pip install torch torchaudio torchvision
+if errorlevel 1 goto :install_failed
+
+:: Wait for installation
+timeout /t 1 /nobreak >nul 2>&1
+
+echo [*] Checking ROCm installation...
+.\python_env\python.exe -m pip install rocm[libraries,devel]
+if errorlevel 1 goto :install_failed
+
+echo [*] Initializing rocm-sdk...
+.\python_env\scripts\rocm-sdk init >nul 2>&1
+if errorlevel 1 (
+    echo [^^!] Warning: rocm-sdk init failed, continuing anyway...
 )
 
-if "!arch!"=="gfx103X" (
-    echo [*] Installing ROCm for RDNA2 ^(gfx103X^)...
-    .\python_env\python.exe -m pip install rocm[devel,libraries] --index-url https://rocm.nightlies.amd.com/v2-staging/gfx103X-dgpu/ --no-warn-script-location >nul 2>&1
-    if errorlevel 1 goto :install_failed
-    .\python_env\scripts\rocm-sdk init >nul 2>&1 
-    if errorlevel 1 (
-        echo [!] Warning: rocm-sdk init failed, continuing anyway...
-    )
-	echo [*] Installing PyTorch for RDNA2 ^(gfx103X^)...
-    .\python_env\python.exe -m pip install --index-url https://rocm.nightlies.amd.com/v2-staging/gfx103X-dgpu/ torch torchaudio torchvision --no-warn-script-location >nul 2>&1
-    if errorlevel 1 goto :install_failed
-    goto :install_requirements
-)
-
-if "!arch!"=="gfx110X" (
-    echo [*] Installing ROCm for RDNA3 ^(gfx110X^)...
-    .\python_env\python.exe -m pip install rocm[devel,libraries] --index-url https://rocm.nightlies.amd.com/v2/gfx110X-all/ --no-warn-script-location >nul 2>&1
-    if errorlevel 1 goto :install_failed
-    .\python_env\scripts\rocm-sdk init >nul 2>&1 
-    if errorlevel 1 (
-        echo [!] Warning: rocm-sdk init failed, continuing anyway...
-    )
-	echo [*] Installing PyTorch for RDNA3 ^(gfx110X^)...
-    .\python_env\python.exe -m pip install --index-url https://rocm.nightlies.amd.com/v2/gfx110X-all/ torch torchaudio torchvision --no-warn-script-location >nul 2>&1	
-    if errorlevel 1 goto :install_failed
-    goto :install_requirements
-)
-
-if "!arch!"=="gfx1150" (
-    echo [*] Installing ROCm for Strix Point ^(gfx1150^)...
-    .\python_env\python.exe -m pip install rocm[devel,libraries] --index-url https://rocm.nightlies.amd.com/v2-staging/gfx1150/ --no-warn-script-location >nul 2>&1
-    if errorlevel 1 goto :install_failed
-    .\python_env\scripts\rocm-sdk init >nul 2>&1 
-    if errorlevel 1 (
-        echo [!] Warning: rocm-sdk init failed, continuing anyway...
-    )
-	echo [*] Installing PyTorch for Strix Point ^(gfx1150^)...
-    .\python_env\python.exe -m pip install --index-url https://rocm.nightlies.amd.com/v2-staging/gfx1150/ torch torchaudio torchvision --no-warn-script-location >nul 2>&1
-    if errorlevel 1 goto :install_failed
-    goto :install_requirements
-)
-
-if "!arch!"=="gfx1151" (
-    echo [*] Installing ROCm for Strix Halo ^(gfx1151^)...
-    .\python_env\python.exe -m pip install rocm[devel,libraries] --index-url https://rocm.nightlies.amd.com/v2/gfx1151/ --no-warn-script-location >nul 2>&1
-    if errorlevel 1 goto :install_failed
-    .\python_env\scripts\rocm-sdk init >nul 2>&1 
-    if errorlevel 1 (
-        echo [!] Warning: rocm-sdk init failed, continuing anyway...
-    )
-	echo [*] Installing PyTorch for Strix Halo ^(gfx1151^)...
-    .\python_env\python.exe -m pip install --index-url https://rocm.nightlies.amd.com/v2/gfx1151/ torch torchaudio torchvision --no-warn-script-location >nul 2>&1	
-    if errorlevel 1 goto :install_failed
-    goto :install_requirements
-)
-
-if "!arch!"=="gfx1152" (
-    echo [*] Installing ROCm for Krackan Point ^(gfx1152^)...
-    .\python_env\python.exe -m pip install rocm[devel,libraries] --index-url https://rocm.nightlies.amd.com/v2-staging/gfx1152/ --no-warn-script-location >nul 2>&1
-    if errorlevel 1 goto :install_failed
-    .\python_env\scripts\rocm-sdk init >nul 2>&1 
-    if errorlevel 1 (
-        echo [!] Warning: rocm-sdk init failed, continuing anyway...
-    )
-	echo [*] Installing PyTorch for Krackan Point ^(gfx1152^)...
-    .\python_env\python.exe -m pip install --index-url https://rocm.nightlies.amd.com/v2-staging/gfx1152/ torch torchaudio torchvision --no-warn-script-location >nul 2>&1	
-    if errorlevel 1 goto :install_failed
-    goto :install_requirements
-)
-
-if "!arch!"=="gfx1153" (
-    echo [*] Installing ROCm for RDNA 3.5 ^(gfx1153^)...
-    .\python_env\python.exe -m pip install rocm[devel,libraries] --index-url https://rocm.nightlies.amd.com/v2-staging/gfx1153/ --no-warn-script-location >nul 2>&1
-    if errorlevel 1 goto :install_failed
-    .\python_env\scripts\rocm-sdk init >nul 2>&1 
-    if errorlevel 1 (
-        echo [!] Warning: rocm-sdk init failed, continuing anyway...
-    )
-	echo [*] Installing PyTorch for RDNA 3.5 ^(gfx1153^)...
-    .\python_env\python.exe -m pip install --index-url https://rocm.nightlies.amd.com/v2-staging/gfx1153/ torch torchaudio torchvision --no-warn-script-location >nul 2>&1
-    if errorlevel 1 goto :install_failed
-    goto :install_requirements
-)
-
-if "!arch!"=="gfx120X" (
-    echo [*] Installing ROCm for RDNA4 ^(gfx120X^)...
-    .\python_env\python.exe -m pip install rocm[devel,libraries] --index-url https://rocm.nightlies.amd.com/v2/gfx120X-all/ --no-warn-script-location >nul 2>&1
-    if errorlevel 1 goto :install_failed
-    .\python_env\scripts\rocm-sdk init >nul 2>&1 
-    if errorlevel 1 (
-        echo [!] Warning: rocm-sdk init failed, continuing anyway...
-    )
-	echo [*] Installing PyTorch for RDNA4 ^(gfx120X^)...
-    .\python_env\python.exe -m pip install --pre --index-url https://rocm.nightlies.amd.com/v2/gfx120X-all/ torch torchaudio torchvision --no-warn-script-location >nul 2>&1
-    if errorlevel 1 goto :install_failed
-    goto :install_requirements
-)
-
-if "!arch!"=="gfx90X" (
-    echo [*] Installing ROCm for Radeon Pro VII ^(gfx90X^)...
-    .\python_env\python.exe -m pip install rocm[devel,libraries] --index-url https://rocm.nightlies.amd.com/v2-staging/gfx90X-dcgpu/ --no-warn-script-location >nul 2>&1
-    if errorlevel 1 goto :install_failed
-    .\python_env\scripts\rocm-sdk init >nul 2>&1 
-    if errorlevel 1 (
-        echo [!] Warning: rocm-sdk init failed, continuing anyway...
-    )
-	echo [*] Installing PyTorch for Radeon Pro VII ^(gfx90X^)...
-    .\python_env\python.exe -m pip install --index-url https://rocm.nightlies.amd.com/v2-staging/gfx90X-dcgpu/ torch torchaudio torchvision --no-warn-script-location >nul 2>&1
-    if errorlevel 1 goto :install_failed
-    goto :install_requirements
-)
-
-if "!arch!"=="gfx94X" (
-    echo [*] Installing ROCm for MI300/MI325 ^(gfx94X^)...
-    .\python_env\python.exe -m pip install rocm[devel,libraries] --index-url https://rocm.nightlies.amd.com/v2-staging/gfx94X-dcgpu/ --no-warn-script-location >nul 2>&1
-    if errorlevel 1 goto :install_failed
-    .\python_env\scripts\rocm-sdk init >nul 2>&1 
-    if errorlevel 1 (
-        echo [!] Warning: rocm-sdk init failed, continuing anyway...
-    )
-	echo [*] Installing PyTorch for MI300/MI325 ^(gfx94X^)...
-    .\python_env\python.exe -m pip install --index-url https://rocm.nightlies.amd.com/v2-staging/gfx94X-dcgpu/ torch torchaudio torchvision --no-warn-script-location >nul 2>&1
-    if errorlevel 1 goto :install_failed
-    goto :install_requirements
-)
-
-if "!arch!"=="gfx950" (
-    echo [*] Installing ROCm for MI350/MI355 ^(gfx950^)...
-    .\python_env\python.exe -m pip install rocm[devel,libraries] --index-url https://rocm.nightlies.amd.com/v2-staging/gfx950-dcgpu/ --no-warn-script-location >nul 2>&1
-    if errorlevel 1 goto :install_failed
-    .\python_env\scripts\rocm-sdk init >nul 2>&1 
-    if errorlevel 1 (
-        echo [!] Warning: rocm-sdk init failed, continuing anyway...
-    )
-	echo [*] Installing PyTorch for MI350/MI355 ^(gfx950^)...
-    .\python_env\python.exe -m pip install --index-url https://rocm.nightlies.amd.com/v2-staging/gfx950-dcgpu/ torch torchaudio torchvision --no-warn-script-location >nul 2>&1
-    if errorlevel 1 goto :install_failed
-    goto :install_requirements
-)
-
-echo [!] Unknown GPU architecture detected: !arch!
-pause
-exit /b 1
-
-:install_requirements
 echo.
 echo [*] Installing comfyui-rocm...
 
 :: Check if requirements.txt exists
 if not exist "requirements.txt" (
-    echo [!] Error: requirements.txt not found!
+    echo [^^!] Error: requirements.txt not found!
     pause
     exit /b 1
 )
 
-.\python_env\python.exe -m pip install -r requirements.txt --no-warn-script-location >nul 2>&1
+.\python_env\python.exe -m pip install -r requirements.txt
 if errorlevel 1 goto :install_failed
 
 echo [*] Installing extensions...
@@ -323,9 +191,9 @@ if not exist ComfyUI-HFRemoteVae git clone https://github.com/kijai/ComfyUI-HFRe
 cd ..
 
 echo [*] Installing triton - sageattention(v1)
-.\python_env\python.exe -m pip install triton-windows==3.6.0.post25 --quiet
+.\python_env\python.exe -m pip install triton-windows==3.6.0.post25
 if errorlevel 1 goto :install_failed
-.\python_env\python.exe -m pip install sageattention==1.0.6 --quiet
+.\python_env\python.exe -m pip install sageattention==1.0.6
 if errorlevel 1 goto :install_failed
 
 echo [*] Patching sage-attention...
@@ -335,8 +203,6 @@ del python_env\Lib\site-packages\sageattention\attn_qk_int8_per_block_causal.py 
 curl -sL -o python_env\Lib\site-packages\sageattention\attn_qk_int8_per_block_causal.py https://raw.githubusercontent.com/patientx/ComfyUI-Zluda/refs/heads/master/comfy/customzluda/sa/attn_qk_int8_per_block_causal.py
 del python_env\Lib\site-packages\sageattention\quant_per_block.py >NUL
 curl -sL -o python_env\Lib\site-packages\sageattention\quant_per_block.py https://raw.githubusercontent.com/patientx/ComfyUI-Zluda/refs/heads/master/comfy/customzluda/sa/quant_per_block.py
-
-echo [*] Installing bitsandbytes if available...
 
 :: Skip unsupported architectures (MI300/MI350 series) as they are not supported by prebuilt wheels
 for %%G in (gfx90X gfx94X gfx950) do (
@@ -348,19 +214,19 @@ for %%G in (gfx90X gfx94X gfx950) do (
 
 :: Install unified RDNA build
 echo [*] Installing bitsandbytes (unified RDNA build)...
-.\python_env\python.exe -m pip install https://github.com/0xDELUXA/bitsandbytes_win_rocm/releases/download/0.50.0.dev0-py3-rocm7-win_amd64_rdna/bitsandbytes-0.50.0.dev0-cp312-cp312-win_amd64.whl --quiet
+.\python_env\python.exe -m pip install https://github.com/bitsandbytes-foundation/bitsandbytes/releases/download/continuous-release_main/bitsandbytes-1.33.7.preview-py3-none-win_amd64.whl
 if errorlevel 1 goto :install_failed
 
 :bnb_done
 
 echo [*] Installing flash-attention (aiter triton backend)...
-.\python_env\python.exe -m pip install https://github.com/0xDELUXA/flash-attention/releases/download/v2.8.4_win-rocm/flash_attn-2.8.4-py3-none-win_amd64.whl --quiet
+.\python_env\python.exe -m pip install https://github.com/0xDELUXA/flash-attention/releases/download/v2.8.4_win-rocm/flash_attn-2.8.4-py3-none-win_amd64.whl
 if errorlevel 1 (
-    echo [!] Warning: flash-attention install failed, skipping...
+    echo [^^!] Warning: flash-attention install failed, skipping...
     goto :fa_done
 )
-.\python_env\python.exe -m pip install https://github.com/0xDELUXA/flash-attention/releases/download/v2.8.4_win-rocm/amd_aiter-0.0.0-py3-none-win_amd64.whl --quiet
-if errorlevel 1 echo [!] Warning: aiter install failed, flash-attention will not work...
+.\python_env\python.exe -m pip install https://github.com/0xDELUXA/flash-attention/releases/download/v2.8.4_win-rocm/amd_aiter-0.0.0-py3-none-win_amd64.whl
+if errorlevel 1 echo [^^!] Warning: aiter install failed, flash-attention will not work...
 
 :fa_done
 
@@ -370,8 +236,8 @@ echo [*] Verifying installation...
 echo.
 .\python_env\python.exe -c "import torch; print(f'PyTorch Version: {torch.__version__}'); print(f'ROCm Available: {torch.cuda.is_available()}'); print(f'ROCm Version: {torch.version.hip if torch.cuda.is_available() else \"N/A\"}')"
 if errorlevel 1 (
-    echo [!] Warning: Installation verification failed
-    echo [!] PyTorch may not be properly installed
+    echo [^^!] Warning: Installation verification failed
+    echo [^^!] PyTorch may not be properly installed
 )
 
 goto :install_complete


### PR DESCRIPTION
I tried `install.bat` and found some issues:

## Necessary

In [TheRock/pytorch/README](https://github.com/ROCm/TheRock/blob/main/external-builds/pytorch/README.md#gating-releases-with-pytorch-tests) it says 

>With passing builds we upload `torch`, `torchvision`, `torchaudio`, `triton`, and `apex` wheels to subfolders of the "v2-staging" directory in the nightly release s3 bucket with a public URL at https://rocm.nightlies.amd.com/v2-staging/
>
>Only with passing Torch tests we promote passed wheels to the "v2" directory in the nightly release s3 bucket with a public URL at https://rocm.nightlies.amd.com/v2/

So `/v2` is tests passed stabled releases and `/v2-staging` should not be used.

Run `pip install rocm[devel,libraries]` first will always install the latest build like `rocm-sdk 7.13.0a20260414`, but then run `pip install torch` might only get `torch 7.13.0a20260409`, this will uninstall the `rocm-sdk 7.13.0a20260414` you just installed and install `rocm-sdk 7.13.0a20260409` instead.

- Fix: Run `pip install torch torchaudio torchvision` first, it will auto collect needed rocm-sdk `core` and `libraries`, then run `pip install rocm[devel,libraries]` will add the matching `devel`

When installation failed, the script prints `Check the error messages above for details.` but there was no error message.

- Fix: Remove several unnecessary `>nul 2>&1`

`echo !` won't print because of `setlocal enabledelayedexpansion` set.

- Fix: use `echo ^^!` instead.

User might have set `PIP_REQUIRE_VIRTUALENV=true` for safety, and block script running,

- Fix: set "PIP_REQUIRE_VIRTUALENV=false" in script.

## QOL

- bitsandbytes supports Windows ROCm CI now https://github.com/bitsandbytes-foundation/bitsandbytes/pull/1915 so we could use the nightly build via https://github.com/bitsandbytes-foundation/bitsandbytes/releases/tag/continuous-release_main.

- `detect_gpu.py` already got a lot of GPU information so we can just add an `arch_index` map to make better use of those.

- Use `PIP_NO_WARN_SCRIPT_LOCATION` and `PIP_QUIET` in script for quick environment installation debug.
