### PR TITLE
Fix: Properly detect RDNA4 AI Pro GPUs

### DIFF
--- a/detect_gpu.py
+++ b/detect_gpu.py
@@ -7,7 +7,7 @@ import os
 GPU_TO_GFX = [
     # RDNA4 (gfx12xx)
     (['rx 9060'], 'gfx120X', 'RDNA 4', True),
-    (['rx 9070', 'r9070'], 'gfx120X', 'RDNA 4', True),
+    (['rx 9070', 'r9700', 'r9600'], 'gfx120X', 'RDNA 4', True),
     
     # RDNA3.5 (gfx115x)
     (['890m'], 'gfx1150', 'Strix Point', True),


### PR DESCRIPTION
The current mapping has the, assuming intended, detection of the R9700 mistakenly listed as 'r9070'.

The detect_gpu.py script fails to present a gfx family designation due to this when it pulls "R9700" from the Windows adapter name.

- Changed 'r9070' -> 'r9700' :  will also cover the R9700S.
- Added 'r9600' : Adds detection for R9600D card of the same family.