### PR TITLE
Remove gfx908 and gfx90a from unsupported architectures by bnb

### DIFF
--- a/install.bat
+++ b/install.bat
@@ -395,7 +395,7 @@ curl -sL -o python_env\Lib\site-packages\sageattention\quant_per_block.py https:
 echo [*] Installing bitsandbytes if available...
 
 :: Skip unsupported architectures for bitsandbytes prebuilt wheels
-for %%G in (gfx90X gfx900 gfx906 gfx908 gfx90a) do (
+for %%G in (gfx90X gfx900 gfx906) do (
     if /I "!arch!"=="%%G" (
         echo [*] Skipping bitsandbytes for !arch! - prebuilt wheels are not available, build from source required
         goto :bnb_done


### PR DESCRIPTION
Instinct GPUs (`gfx908` and `gfx90a`) are [supported](https://github.com/0xDELUXA/bitsandbytes_win_rocm/releases/tag/0.50.0.dev0-py3-rocm7-win_amd64_all) by the bnb wheel, Vega isn't.