### PR TITLE
Fix legacy GPU detection in comfyui-rocm.bat

### DIFF
--- a/comfyui-rocm.bat
+++ b/comfyui-rocm.bat
@@ -34,8 +34,8 @@ echo %GREEN%[INFO]%RESET% Detecting GPU architecture...
 set "GPU_ARCH="
 for /f "delims=" %%A in ('.\python_env\python.exe detect_gpu.py 2^>nul') do set "GPU_ARCH=%%A"
 set "IS_LEGACY_GPU=0"
-if /I "!GPU_ARCH!"=="gfx101X" set "IS_LEGACY_GPU=1"
-if /I "!GPU_ARCH!"=="gfx103X" set "IS_LEGACY_GPU=1"
+if /I "!GPU_ARCH:~0,6!"=="gfx101" set "IS_LEGACY_GPU=1"
+if /I "!GPU_ARCH:~0,6!"=="gfx103" set "IS_LEGACY_GPU=1"
 
 if "!GPU_ARCH!"=="" (
     echo %YELLOW%[WARN]%RESET% Could not detect GPU architecture.


### PR DESCRIPTION
`detect_gpu.py` returns the exact GPU ID (e.g. gfx1011, gfx1030), not a category pattern (gfx101X, gfx103X), so the old string comparisons never matched anything. Instead, match on the first 6 characters to cover the full gfx generation.

Anecdotally, I get about 8% better performance on my RX6900XT with the legacy tweaks enabled.