### PR TITLE
bitsandbytes ROCm 7.15 support

### DIFF
--- a/install.bat
+++ b/install.bat
@@ -290,7 +290,7 @@ echo %GREEN%[*]%RESET% Installing bitsandbytes if available...
 
 :: Install bitsandbytes
 echo %GREEN%[*]%RESET% Installing bitsandbytes...
-.\python_env\python.exe -m pip install https://github.com/0xDELUXA/bitsandbytes_win_rocm/releases/download/0.50.0.dev0-py3.12-rocm7.14-win_amd64_all/bitsandbytes-0.50.0.dev0-cp312-cp312-win_amd64.whl %QQ%
+.\python_env\python.exe -m pip install https://github.com/0xDELUXA/bitsandbytes_win_rocm/releases/download/0.50.0.dev0-py3.12-rocm7.15-win_amd64_all/bitsandbytes-0.50.0.dev0-cp312-cp312-win_amd64.whl %QQ%
 if errorlevel 1 goto :install_failed
 
 :bnb_done


### PR DESCRIPTION
Add ROCm 7.15 support for bnb. This wheel covers 7.13-7.15.